### PR TITLE
Parse tabledap search results

### DIFF
--- a/src/erddap-parser.js
+++ b/src/erddap-parser.js
@@ -144,8 +144,20 @@ export default {
 
 			return dataCsv;
 		},
-		parseTabledapSearchSesults:function(searchCsv){
-			return searchCsv;
+		/**
+		 * Parse search csv data to ensure keys are lowercase and spaces
+		 * converted to underscores.
+		 * @param {Object} searchCsv - an object containing the input csv data
+		 */
+		parseTabledapSearchResults:function(searchCsv){
+
+			return searchCsv.map(d =>{
+				var result = {};
+				for (const [key, value] of Object.entries(d)) {
+					result[key.toLowerCase().replace(/\s+/g,"_")] = value;
+				}
+				return result;
+			});
 		},
 		parseDatasetMetadata:function(metadataCsv){
 

--- a/test/erddap-parser-parseTabledapSearchResults-test.js
+++ b/test/erddap-parser-parseTabledapSearchResults-test.js
@@ -1,0 +1,15 @@
+const tape = require("tap").test,
+    erddapParser = require("../build/erddap-parser").erddapParser
+    testTabledapSearchResults = require('./test_tabledapsearchresults.json'),
+    expectedParsedTabledapSearchResults = require('./expected_tabledapsearchresults.json')
+
+tape("parseTabledapSearchResults() formats data correctly", function(test){
+    
+    var tabledapsearchresults_csv = testTabledapSearchResults,
+    expected = expectedParsedTabledapSearchResults,
+    tabledapsearchresults = erddapParser.parseTabledapSearchResults(tabledapsearchresults_csv, );
+
+    test.deepEqual(tabledapsearchresults[0], expected)
+    test.end();
+
+})

--- a/test/expected_tabledapsearchresults.json
+++ b/test/expected_tabledapsearchresults.json
@@ -1,0 +1,17 @@
+{
+"background_info": "https://sensors.ioos.us/?sensor_version=v2#metadata/38228/station",
+"dataset_id": "gov_noaa_water_kasn6",
+"fgdc": "http://erddap.sensors.axds.co/erddap/metadata/fgdc/xml/gov_noaa_water_kasn6_fgdc.xml",
+"iso_19115": "http://erddap.sensors.axds.co/erddap/metadata/iso19115/xml/gov_noaa_water_kasn6_iso19115.xml",
+"info": "http://erddap.sensors.axds.co/erddap/info/gov_noaa_water_kasn6/index.csv",
+"institution": "NOAA Water Resources Regions, National Weather Service",
+"make_a_graph": "http://erddap.sensors.axds.co/erddap/tabledap/gov_noaa_water_kasn6.graph",
+"rss": "http://erddap.sensors.axds.co/erddap/rss/gov_noaa_water_kasn6.rss",
+"subset": "",
+"summary": "Timeseries data from 'West Canada Creek at Kast Bridge (New York)' (urn:ioos:station:gov.noaa.water:KASN6)\n\ncdm_data_type = TimeSeries\nVARIABLES:\ntime (seconds since 1970-01-01T00:00:00Z)\nlatitude (degrees_north)\nlongitude (degrees_east)\nz (m)\nriver_discharge (Stream Flow, m3.s-1)\nheight_geoid_local_station_datum (Stream Height, m)\nwater_surface_height_above_reference_datum_geoid_localstationdatum (Water Surface Height above Datum, m)\nstation (West Canada Creek at Kast Bridge (New York))\n",
+"title": "West Canada Creek at Kast Bridge (New York)",
+"files": "",
+"griddap": "",
+"tabledap": "http://erddap.sensors.axds.co/erddap/tabledap/gov_noaa_water_kasn6",
+"wms": ""
+}

--- a/test/test_tabledapsearchresults.json
+++ b/test/test_tabledapsearchresults.json
@@ -1,0 +1,17 @@
+[
+    {"Background Info": "https://sensors.ioos.us/?sensor_version=v2#metadata/38228/station",
+     "Dataset ID": "gov_noaa_water_kasn6",
+     "FGDC": "http://erddap.sensors.axds.co/erddap/metadata/fgdc/xml/gov_noaa_water_kasn6_fgdc.xml",
+     "ISO 19115": "http://erddap.sensors.axds.co/erddap/metadata/iso19115/xml/gov_noaa_water_kasn6_iso19115.xml",
+     "Info": "http://erddap.sensors.axds.co/erddap/info/gov_noaa_water_kasn6/index.csv",
+     "Institution": "NOAA Water Resources Regions, National Weather Service",
+     "Make A Graph": "http://erddap.sensors.axds.co/erddap/tabledap/gov_noaa_water_kasn6.graph",
+     "RSS": "http://erddap.sensors.axds.co/erddap/rss/gov_noaa_water_kasn6.rss",
+     "Subset": "",
+     "Summary": "Timeseries data from 'West Canada Creek at Kast Bridge (New York)' (urn:ioos:station:gov.noaa.water:KASN6)\n\ncdm_data_type = TimeSeries\nVARIABLES:\ntime (seconds since 1970-01-01T00:00:00Z)\nlatitude (degrees_north)\nlongitude (degrees_east)\nz (m)\nriver_discharge (Stream Flow, m3.s-1)\nheight_geoid_local_station_datum (Stream Height, m)\nwater_surface_height_above_reference_datum_geoid_localstationdatum (Water Surface Height above Datum, m)\nstation (West Canada Creek at Kast Bridge (New York))\n",
+     "Title": "West Canada Creek at Kast Bridge (New York)",
+     "files": "",
+     "griddap": "",
+     "tabledap": "http://erddap.sensors.axds.co/erddap/tabledap/gov_noaa_water_kasn6",
+     "wms": ""}
+]


### PR DESCRIPTION
Keys returned from Tabledap search results are wrangled to be lower-case and spaces replaced with underscores.

Included new test for parseTabledapSearchResults

#iooscodesprint